### PR TITLE
Wait for servers QUIT response before TCP session close

### DIFF
--- a/src/main/java/me/normanmaurer/niosmtp/delivery/chain/ChainedSMTPClientFutureListener.java
+++ b/src/main/java/me/normanmaurer/niosmtp/delivery/chain/ChainedSMTPClientFutureListener.java
@@ -161,9 +161,6 @@ public abstract class ChainedSMTPClientFutureListener<E> implements SMTPClientFu
             future.setResult(resultList);
 
             next(session, SMTPRequestImpl.quit());
-            session.close();
-
-
         } else {
             initSession(session);
             if (session.getSupportedExtensions().contains(PIPELINING_EXTENSION) && ((SMTPDeliveryAgentConfig)session.getConfig()).getPipeliningMode() != PipeliningMode.NO) {

--- a/src/main/java/me/normanmaurer/niosmtp/delivery/chain/QuitResponseListener.java
+++ b/src/main/java/me/normanmaurer/niosmtp/delivery/chain/QuitResponseListener.java
@@ -1,0 +1,52 @@
+/**
+* Licensed to niosmtp developers ('niosmtp') under one or more
+* contributor license agreements. See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* niosmtp licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package me.normanmaurer.niosmtp.delivery.chain;
+
+import me.normanmaurer.niosmtp.SMTPClientFuture;
+import me.normanmaurer.niosmtp.SMTPClientFutureListener;
+import me.normanmaurer.niosmtp.SMTPResponse;
+import me.normanmaurer.niosmtp.transport.FutureResult;
+
+
+/**
+ * {@link me.normanmaurer.niosmtp.delivery.chain.ChainedSMTPClientFutureListener} implementation which will run after a
+ * QUIT request.
+ * <p/>
+ * It will simply close the session, regardless of the server response.
+ *
+ *
+ * @author Raman Gupta
+ *
+ */
+public class QuitResponseListener implements SMTPClientFutureListener<FutureResult<SMTPResponse>> {
+
+    /**
+     * Get instance of this {@link me.normanmaurer.niosmtp.delivery.chain.QuitResponseListener} implementation
+     */
+    public final static QuitResponseListener INSTANCE = new QuitResponseListener();
+
+    private QuitResponseListener() {
+
+    }
+
+    @Override
+    public void operationComplete(SMTPClientFuture<FutureResult<SMTPResponse>> smtpResponseSMTPClientFuture) {
+        // close the session no matter what the server returned
+        smtpResponseSMTPClientFuture.getSession().close();
+    }
+
+}

--- a/src/main/java/me/normanmaurer/niosmtp/delivery/chain/SMTPClientFutureListenerFactoryImpl.java
+++ b/src/main/java/me/normanmaurer/niosmtp/delivery/chain/SMTPClientFutureListenerFactoryImpl.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Locale;
 
-import me.normanmaurer.niosmtp.SMTPClientFuture;
 import me.normanmaurer.niosmtp.SMTPClientFutureListener;
 import me.normanmaurer.niosmtp.SMTPMessage;
 import me.normanmaurer.niosmtp.SMTPException;
@@ -34,12 +33,6 @@ import me.normanmaurer.niosmtp.transport.impl.FutureResultImpl;
 
 public class SMTPClientFutureListenerFactoryImpl implements SMTPClientFutureListenerFactory{
 
-    private final static SMTPClientFutureListener<FutureResult<SMTPResponse>> EMPTY = new SMTPClientFutureListener<FutureResult<SMTPResponse>>() {
-
-        @Override
-        public void operationComplete(SMTPClientFuture<FutureResult<SMTPResponse>> future) {            
-        }
-    };
     @Override
     public SMTPClientFutureListener<FutureResult<SMTPResponse>> getListener(SMTPClientSession session, SMTPRequest request) throws SMTPException {
 
@@ -65,7 +58,7 @@ public class SMTPClientFutureListenerFactoryImpl implements SMTPClientFutureList
                 return AuthLoginResponseListener.INSTANCE;
             }
         } else if (SMTPRequest.QUIT_COMMAND.equals(cmd)) {
-            return EMPTY;
+            return QuitResponseListener.INSTANCE;
         }
 
         throw new SMTPException("No valid callback found for request " + request);


### PR DESCRIPTION
When closing the session before the QUIT response was received, niosmtp
would receive the server response packets after the close, resulting in
one or more TCP reset packets being sent back and forth.

Instead, do the close in a new QuitResponseListener.
