### PR TITLE
Handle appropriate SMTP responses for non-EHLO servers

### DIFF
--- a/src/main/java/me/normanmaurer/niosmtp/delivery/chain/EhloResponseListener.java
+++ b/src/main/java/me/normanmaurer/niosmtp/delivery/chain/EhloResponseListener.java
@@ -78,7 +78,9 @@ public class EhloResponseListener extends ChainedSMTPClientFutureListener<SMTPRe
         int code = response.getCode();
 
         String mail = ((SMTPDeliveryEnvelope)session.getAttribute(CURRENT_SMTP_TRANSACTION_KEY)).getSender();
-        if (code < 400) {
+
+        // servers that do not implement EHLO may return 500 (as per RFC 821) or 502 (RFC 1869)
+        if (code < 400 || code == 500 || code == 502) {
 
             // Check if we depend on pipelining 
             if (!supportsPipelining && ((SMTPDeliveryAgentConfig)session.getConfig()).getPipeliningMode() == PipeliningMode.DEPEND) {


### PR DESCRIPTION
Servers that do not implement EHLO may return 500 (as per RFC 821) or 502 (RFC 1869). Handle this as "EHLO not supported" and continue if possible rather than bailing out the entire SMTP transaction.
