### PR TITLE
Handle server/network disconnects during an SMTP session

### DIFF
--- a/src/main/java/me/normanmaurer/niosmtp/SMTPDisconnectedException.java
+++ b/src/main/java/me/normanmaurer/niosmtp/SMTPDisconnectedException.java
@@ -1,0 +1,49 @@
+/**
+* Licensed to niosmtp developers ('niosmtp') under one or more
+* contributor license agreements. See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* niosmtp licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package me.normanmaurer.niosmtp;
+
+/**
+ * {@link me.normanmaurer.niosmtp.SMTPException} which will get thrown if the connection closes unexpectedly.
+ * This most times means that the SMTP Server crashed or that the network connection was interrupted.
+ *
+ * @author Raman Gupta
+ *
+ */
+public class SMTPDisconnectedException extends SMTPException{
+
+    /**
+     *
+     */
+    private static final long serialVersionUID = 2383943619694157245L;
+
+    public SMTPDisconnectedException() {
+        super();
+    }
+
+    public SMTPDisconnectedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public SMTPDisconnectedException(String message) {
+        super(message);
+    }
+
+    public SMTPDisconnectedException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/src/main/java/me/normanmaurer/niosmtp/delivery/SMTPDeliveryAgent.java
+++ b/src/main/java/me/normanmaurer/niosmtp/delivery/SMTPDeliveryAgent.java
@@ -105,6 +105,7 @@ public class SMTPDeliveryAgent implements SMTPClientConstants, SMTPDeliverySessi
                 session.setAttribute(DELIVERY_STATUS_KEY, new ArrayList<DeliveryRecipientStatus>());
                 session.setAttribute(DELIVERY_RESULT_LIST_KEY, new ArrayList<FutureResult<Iterator<DeliveryRecipientStatus>>>());
                 session.setAttribute(SMTP_CLIENT_FUTURE_LISTENER_FACTORY, createFactory());
+                session.setAttribute(SMTP_TRANSACTION_ACTIVE_KEY, false);
             }
 
             @Override

--- a/src/main/java/me/normanmaurer/niosmtp/delivery/SMTPDeliverySessionConstants.java
+++ b/src/main/java/me/normanmaurer/niosmtp/delivery/SMTPDeliverySessionConstants.java
@@ -71,6 +71,12 @@ public interface SMTPDeliverySessionConstants {
     public final static String SMTP_TRANSACTIONS_KEY = "smtp_transactions";
     
     /**
+     * Key under which the state of a transaction within a SMTP session is stored. Transactions are
+     * "active" between the "MAIL FROM" and when the server responds to the "DATA".
+     */
+    public final static String SMTP_TRANSACTION_ACTIVE_KEY = "smtp_transaction_active";
+
+    /**
      * Key under which the current {@link SMTPDeliveryEnvelope} is stored
      */
     public final static String CURRENT_SMTP_TRANSACTION_KEY = "cur_smtp_transaction";

--- a/src/main/java/me/normanmaurer/niosmtp/delivery/chain/MailResponseListener.java
+++ b/src/main/java/me/normanmaurer/niosmtp/delivery/chain/MailResponseListener.java
@@ -61,7 +61,8 @@ public class MailResponseListener extends AbstractPipeliningResponseListener {
             
             // store the current recipient we are processing
             session.setAttribute(CURRENT_RCPT_KEY, rcpt);
-            
+            session.setAttribute(SMTP_TRANSACTION_ACTIVE_KEY, true);
+
             // only write the request if the SMTPServer does not support PIPELINING and we don't want to use it
             // as otherwise we already sent this 
             if (session.getAttribute(PIPELINING_ACTIVE_KEY) == null || ((SMTPDeliveryAgentConfig)session.getConfig()).getPipeliningMode() == PipeliningMode.NO) {

--- a/src/main/java/me/normanmaurer/niosmtp/delivery/chain/PostDataResponseListener.java
+++ b/src/main/java/me/normanmaurer/niosmtp/delivery/chain/PostDataResponseListener.java
@@ -79,6 +79,7 @@ public class PostDataResponseListener extends ChainedSMTPClientFutureListener<Co
             }
 
         }    
+        session.setAttribute(SMTP_TRANSACTION_ACTIVE_KEY, false);
         setDeliveryStatus(session);
     }
 

--- a/src/main/java/me/normanmaurer/niosmtp/transport/netty/NettyConstants.java
+++ b/src/main/java/me/normanmaurer/niosmtp/transport/netty/NettyConstants.java
@@ -52,6 +52,11 @@ public interface NettyConstants {
     public static final String CONNECT_HANDLER_KEY = "connectHandler";
     
     /**
+     * The key to use when adding the {@link SMTPDisconnectHandler} to the {@link ChannelPipeline}
+     */
+    public static final String DISCONNECT_HANDLER_KEY = "disconnectHandler";
+
+    /**
      * The key to use when adding the {@link SMTPResponseDecoder} to the {@link ChannelPipeline}
      */
     public static final String SMTP_RESPONSE_DECODER_KEY = "smtpResponseDecoder";

--- a/src/main/java/me/normanmaurer/niosmtp/transport/netty/internal/SMTPClientPipelineFactory.java
+++ b/src/main/java/me/normanmaurer/niosmtp/transport/netty/internal/SMTPClientPipelineFactory.java
@@ -71,7 +71,8 @@ public class SMTPClientPipelineFactory implements ChannelPipelineFactory, NettyC
         pipeline.addLast(SMTP_PIPELINING_REQUEST_ENCODER_KEY, SMTP_PIPELINING_REQUEST_ENCODER);
 
         pipeline.addLast(CHUNK_WRITE_HANDLER_KEY, new ChunkedWriteHandler());
-        
+        pipeline.addLast(DISCONNECT_HANDLER_KEY, new SMTPDisconnectHandler(future));
+
         // Add the idle timeout handler
         pipeline.addLast(IDLE_HANDLER_KEY, new IdleStateHandler(timer, 0, 0, config.getResponseTimeout()));
         pipeline.addLast(CONNECT_HANDLER_KEY, createConnectHandler());

--- a/src/main/java/me/normanmaurer/niosmtp/transport/netty/internal/SMTPDisconnectHandler.java
+++ b/src/main/java/me/normanmaurer/niosmtp/transport/netty/internal/SMTPDisconnectHandler.java
@@ -1,0 +1,57 @@
+/**
+* Licensed to niosmtp developers ('niosmtp') under one or more
+* contributor license agreements. See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* niosmtp licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package me.normanmaurer.niosmtp.transport.netty.internal;
+
+import me.normanmaurer.niosmtp.SMTPDisconnectedException;
+import me.normanmaurer.niosmtp.SMTPResponse;
+import me.normanmaurer.niosmtp.core.SMTPClientFutureImpl;
+import me.normanmaurer.niosmtp.delivery.SMTPDeliverySessionConstants;
+import me.normanmaurer.niosmtp.transport.FutureResult;
+import me.normanmaurer.niosmtp.transport.SMTPClientSession;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.ChannelStateEvent;
+import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
+
+/**
+ * {@link SimpleChannelUpstreamHandler} implementation which will throw an {@link me.normanmaurer.niosmtp.SMTPDisconnectedException}
+ * if a connection was disconnected unexpectedly.
+ *
+ * @author Raman Gupta
+ *
+ */
+public class SMTPDisconnectHandler extends SimpleChannelUpstreamHandler implements SMTPDeliverySessionConstants {
+
+    private final SMTPClientFutureImpl<FutureResult<SMTPResponse>> future;
+
+    public SMTPDisconnectHandler(SMTPClientFutureImpl<FutureResult<SMTPResponse>> future){
+        this.future = future;
+    }
+
+    private boolean activeTransaction() {
+        final SMTPClientSession session = future.getSession();
+        return session != null && (Boolean) session.getAttribute(SMTP_TRANSACTION_ACTIVE_KEY);
+    }
+
+    @Override
+    public void channelClosed(ChannelHandlerContext ctx, ChannelStateEvent e) throws Exception {
+        if(activeTransaction()) {
+            throw new SMTPDisconnectedException("Connection closed during transaction.");
+        }
+        super.channelClosed(ctx, e);
+    }
+
+}


### PR DESCRIPTION
This pull request should fix issue #26.

I wanted to add a test but wasn't sure the best way to do this with the server test harness.
