### PR TITLE
Add OSGi MANIFEST as created by bundle-plugin to jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
       </plugin>
       <!-- Site generation -->
       <!--


### PR DESCRIPTION
The bundle-plugin is creating the manifest but it needs to be added to the output jar with the maven-jar-plugin configuration. The attached patch fixes this and correctly adds the OSGi meta-data to the jar.
