### PR TITLE
Do not insert extra space between 'MAIL FROM'/'RCPT TO' commands and the given argument

### DIFF
--- a/src/main/java/me/normanmaurer/niosmtp/SMTPRequest.java
+++ b/src/main/java/me/normanmaurer/niosmtp/SMTPRequest.java
@@ -27,19 +27,14 @@ public interface SMTPRequest {
     public final static String STARTTLS_COMMAND = "STARTTLS";
     public final static String HELO_COMMAND = "HELO";
     public final static String EHLO_COMMAND = "EHLO";
-    public final static String MAIL_COMMAND = "MAIL FROM:";
-    public final static String RCPT_COMMAND = "RCPT TO:";
+    public final static String MAIL_COMMAND = "MAIL FROM";
+    public final static String RCPT_COMMAND = "RCPT TO";
     public final static String AUTH_COMMAND = "AUTH";
     public final static String AUTH_PLAIN_ARGUMENT = "PLAIN";
     public final static String AUTH_LOGIN_ARGUMENT = "LOGIN";
     public final static String DATA_COMMAND = "DATA";
     public final static String QUIT_COMMAND = "QUIT";
 
-    /**
-     * Separator which is used to separate the command from the argument
-     */
-    public final static char SEPERATOR = ' ';
-    
     /**
      * Return the command 
      * 
@@ -53,4 +48,11 @@ public interface SMTPRequest {
      * @return argument
      */
     String getArgument();
+
+    /**
+     * Return the separator.
+     *
+     * @return separator
+     */
+    char getSeparator();
 }

--- a/src/main/java/me/normanmaurer/niosmtp/core/SMTPRequestImpl.java
+++ b/src/main/java/me/normanmaurer/niosmtp/core/SMTPRequestImpl.java
@@ -30,11 +30,17 @@ public class SMTPRequestImpl implements SMTPRequest{
 
     private final String command;
     private final String argument;
+    private final char separator;
 
     
-    public SMTPRequestImpl(String command, String argument) {
+    public SMTPRequestImpl(String command, String argument, char separator) {
         this.command = command;
         this.argument = argument;
+        this.separator = separator;
+    }
+
+    public SMTPRequestImpl(String command, String argument) {
+        this(command, argument, ' ');
     }
     
     @Override
@@ -47,6 +53,11 @@ public class SMTPRequestImpl implements SMTPRequest{
         return argument;
     }
     
+    @Override
+    public char getSeparator() {
+        return separator;
+    }
+
     @Override
     public String toString() {
         return StringUtils.toString(this);
@@ -90,7 +101,7 @@ public class SMTPRequestImpl implements SMTPRequest{
      * @return rcpt
      */
     public static SMTPRequest rcpt(String recipient) {
-        return new SMTPRequestImpl("RCPT TO:", "<" + recipient + ">");
+        return new SMTPRequestImpl(RCPT_COMMAND, "<" + recipient + ">", ':');
     }
     
     
@@ -104,7 +115,7 @@ public class SMTPRequestImpl implements SMTPRequest{
         if (sender == null) {
             sender = "";
         }
-        return new SMTPRequestImpl("MAIL FROM:",  "<" + sender + ">");
+        return new SMTPRequestImpl(MAIL_COMMAND,  "<" + sender + ">", ':');
     }
     
     /**

--- a/src/main/java/me/normanmaurer/niosmtp/core/StringUtils.java
+++ b/src/main/java/me/normanmaurer/niosmtp/core/StringUtils.java
@@ -74,7 +74,7 @@ public class StringUtils implements SMTPClientConstants{
         if (argument == null) {
             return command;
         } else {
-            return command + SMTPRequest.SEPERATOR + argument;
+            return command + request.getSeparator() + argument;
         }
     }
     


### PR DESCRIPTION
Actually (RFC 5321) there is no space between the 'MAIL FROM' or 'RCPT TO' command and its argument. The separation between one of those commands and its argument is only the colon character.
Some servers (e.g. cyrus LMTP) fail if there is a space.

This pull request points to a commit that fixes the issue. I simply adapted the current code to have the separator as a new optional parameter when creating an SMTP command. Of course, feel free to fix the issue in any other way you think is more adapted.

Regards
